### PR TITLE
assert that Go 1.18 is safe

### DIFF
--- a/untested.go
+++ b/untested.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build go1.18
+//go:build go1.19
+// +build go1.19
 
 package assume_no_moving_gc
 


### PR DESCRIPTION
It is so far, and that ain't changing.
