### PR TITLE
Assert that Go 1.20 is safe

### DIFF
--- a/untested.go
+++ b/untested.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.20
-// +build go1.20
+//go:build go1.21
+// +build go1.21
 
 package assume_no_moving_gc
 


### PR DESCRIPTION
Should we assume that Go 1.20 is safe?